### PR TITLE
Updating RDGW instance types to align with RDGW domain template.

### DIFF
--- a/templates/iis-main.template.yaml
+++ b/templates/iis-main.template.yaml
@@ -381,6 +381,8 @@ Parameters:
   RDGWInstanceType:
     Default: t2.large
     AllowedValues:
+      - t2.small
+      - t2.medium
       - t2.large
       - t3.micro
       - t3.small
@@ -397,6 +399,7 @@ Parameters:
       - m5.large
       - m5.xlarge
       - m5.2xlarge
+      - m5.4xlarge
       - m5a.large
       - m5a.xlarge
       - m5a.2xlarge


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Update iis-main.template.yaml template to mirror the allowed instance type selection for RDGWInstanceType per rdgw-domain.template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
