### PR TITLE
disable IMDSv1 to use IMDSv2 only.

### DIFF
--- a/templates/ec2-asg-lch.template.yaml
+++ b/templates/ec2-asg-lch.template.yaml
@@ -210,6 +210,8 @@ Resources:
             Tags:
               - Key: "DomainToJoin"
                 Value: !Ref "DomainDNSName"
+        MetadataOptions:
+          HttpTokens: Required
   ALBResource:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In order to benefit from the improved security posture that IMDSv2 provides we are configuring EC2 instances to disable IMDSv1 and use IMDSv2 only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
