### PR TITLE
Updating SetupConfigurationDoc to remove explicit version parameter.

### DIFF
--- a/templates/automation-parts.template.yaml
+++ b/templates/automation-parts.template.yaml
@@ -446,8 +446,6 @@ Resources:
                   - "Uninstall and reinstall"
                 name:
                   - "AmazonCloudWatchAgent"
-                version:
-                  - "latest"
           - name: "configureCloudWatchAgent"
             action: aws:runCommand
             onFailure: step:abandonHookAction


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Removes explicit listing of version when executing AWS-ConfigureAWSPackage. By default, latest document version will be utilized if not specified. Encountered issues in ap-southeast-3 yielding the following error:

`failed to download manifest - failed to retrieve package document description: InvalidDocument: Document with name AmazonCloudWatchAgent with version latest does not exist.`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
